### PR TITLE
Update migration-guide-beta.17-to-beta.18.md

### DIFF
--- a/docs/v3.x/migration-guide/migration-guide-beta.17-to-beta.18.md
+++ b/docs/v3.x/migration-guide/migration-guide-beta.17-to-beta.18.md
@@ -598,7 +598,7 @@ toGlobalId = name => upperFirst(camelCase(`group_${name}`));
 ```js
 db.getCollection('contentTypeCollection').update(
   { 'componentField.kind': 'GroupsMyGroup' },
-  { $set: { 'componentField.$.kind': 'ComponentCategoryMyComponent' } },
+  { $set: { 'componentField.$[].kind': 'ComponentCategoryMyComponent' } },
   { multi: true }
 );
 ```


### PR DESCRIPTION
Replace positional operator ($) with all positional operator($[])

<!--
Hello 👋 Thank you for submitting a pull request.

To help us merge your PR, make sure to follow the instructions below:

- Create or update the documentation. (Should be made against the documentation branch) 
- Create or update the tests.
- Refer to the issue you are closing in the PR description - fix #issue
- Specify if the PR is in WIP (work in progress) state or ready to be merged

Please ensure you read through the Contributing Guide: https://github.com/strapi/strapi/blob/docs/contribguide/CONTRIBUTING.md
-->

#### Description of what you did:

During the migration, I ran into the problem while updating the `kind` attribute: in my repeatable groups `kind` was updated only in first element. I fixed it using all positional operator $[] in update 